### PR TITLE
Improved performance

### DIFF
--- a/src/main/java/psidev/psi/tools/xxindex/StandardXmlElementExtractor.java
+++ b/src/main/java/psidev/psi/tools/xxindex/StandardXmlElementExtractor.java
@@ -21,7 +21,7 @@ import java.util.Set;
  * Date: 24-Jul-2007
  */
 @Deprecated
-public class StandardXmlElementExtractor implements XmlElementExtractor {
+public class StandardXmlElementExtractor {
 
     Logger log = LoggerFactory.getLogger(StandardXmlElementExtractor.class);
 

--- a/src/main/java/psidev/psi/tools/xxindex/XmlElementExtractor.java
+++ b/src/main/java/psidev/psi/tools/xxindex/XmlElementExtractor.java
@@ -1,6 +1,5 @@
 package psidev.psi.tools.xxindex;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
@@ -12,9 +11,9 @@ import java.net.URL;
 public interface XmlElementExtractor {
     int setEncoding(String encoding);
 
-    byte[] readBytes(long from, long to, File file) throws IOException;
+    byte[] readBytes(long from, long to) throws IOException;
 
-    String readString(long from, long to, File file) throws IOException;
+    String readString(long from, long to) throws IOException;
 
     String detectFileEncoding(URL fileLocation) throws IOException;
 

--- a/src/main/java/psidev/psi/tools/xxindex/index/XmlXpathIndexer.java
+++ b/src/main/java/psidev/psi/tools/xxindex/index/XmlXpathIndexer.java
@@ -120,7 +120,7 @@ public class XmlXpathIndexer {
      * @see this#buildIndex(java.io.InputStream)
      */
     public static StandardXpathIndex buildIndex(InputStream is, Set<String> aXpathInclusionSet, boolean recordLineNumber, boolean ignoreNSPrefix) throws IOException {
-        BufferedInputStream bufStream = new BufferedInputStream(is);
+        BufferedInputStream bufStream = new BufferedInputStream(is, 1000000);
 
         InputStream tmpStream;
         DigestInputStream digestStream;
@@ -258,8 +258,8 @@ public class XmlXpathIndexer {
             index.setChecksum(checksumHexString);
         }
 
-        countStream.close();
-        is.close();
+        // countStream.close();
+        // is.close();
         return index;
     }
 

--- a/src/test/java/psidev/psi/tools/xxindex/GzXmlElementExtractorTest.java
+++ b/src/test/java/psidev/psi/tools/xxindex/GzXmlElementExtractorTest.java
@@ -42,9 +42,9 @@ public class GzXmlElementExtractorTest {
         IndexElement element = indexElements.get(0);
         Assert.assertNotNull(element);
 
-        GzXmlElementExtractor extractor = new GzXmlElementExtractor();
+        GzXmlElementExtractor extractor = new GzXmlElementExtractor(xmlFile);
 
-        String readString = extractor.readString(element.getStart(), element.getStop(), xmlFile);
+        String readString = extractor.readString(element.getStart(), element.getStop());
         // check that we are in the right area
         Assert.assertTrue(readString.contains("researcher"));
         // now check that we have everything from the start tag
@@ -60,7 +60,7 @@ public class GzXmlElementExtractorTest {
         element = indexElements.get(0);
         Assert.assertNotNull(element);
 
-        readString = extractor.readString(element.getStart(), element.getStop(), xmlFile);
+        readString = extractor.readString(element.getStart(), element.getStop());
         // check that we are in the right area
         Assert.assertTrue(readString.contains("David M. Creasy"));
         // now check that we have everything from the start tag
@@ -99,13 +99,13 @@ public class GzXmlElementExtractorTest {
         IndexElement element = indexElements.get(0);
         Assert.assertNotNull(element);
 
-        GzXmlElementExtractor extractor = new GzXmlElementExtractor();
 
         // this should throw an exception
         String readString = null;
         caughtException = false;
         try {
-            readString = extractor.readString(element.getStart(), element.getStop(), xmlFile);
+            GzXmlElementExtractor extractor = new GzXmlElementExtractor(xmlFile);
+            readString = extractor.readString(element.getStart(), element.getStop());
             Assert.fail("We should have never got to this point! (using a GzExtractor on a non-gz file)");
         } catch (IllegalArgumentException iae) {
             caughtException = true;

--- a/src/test/java/psidev/psi/tools/xxindex/PsiMiIndexingTest.java
+++ b/src/test/java/psidev/psi/tools/xxindex/PsiMiIndexingTest.java
@@ -60,11 +60,11 @@ public class PsiMiIndexingTest {
         Assert.assertEquals( 10, index.getElementCount( "/entrySet/entry/interactionList/interaction/participantList/participant/featureList/feature" ) );
 
         // now let's extract a few stuffs
-        SimpleXmlElementExtractor xee = new SimpleXmlElementExtractor();
+        SimpleXmlElementExtractor xee = new SimpleXmlElementExtractor(file);
         final List<IndexElement> ranges = index.getElements( "/entrySet/entry/interactionList/interaction" );
         Assert.assertEquals( 7, ranges.size() );
         final IndexElement element = ranges.get( 0 );
-        final String xml = xee.readString( element, file );
+        final String xml = xee.readString( element );
     }
 
 

--- a/src/test/java/psidev/psi/tools/xxindex/XmlXpathIndexerTest.java
+++ b/src/test/java/psidev/psi/tools/xxindex/XmlXpathIndexerTest.java
@@ -31,11 +31,11 @@ public class XmlXpathIndexerTest {
     private String readByteRange( long from, long to, String filename, String encoding ) throws Exception {
         URL url = XmlXpathIndexerTest.class.getResource( filename );
         File f = new File( url.toURI() );
-        SimpleXmlElementExtractor xee = new SimpleXmlElementExtractor();
+        SimpleXmlElementExtractor xee = new SimpleXmlElementExtractor(f);
         if (encoding != null) {
             xee.setEncoding( encoding );
         }
-        return xee.readString( from, to, f );
+        return xee.readString( from, to );
     }
 
     private List<String> createTestFileList() {
@@ -61,10 +61,11 @@ public class XmlXpathIndexerTest {
         return fileList;
     }
 
-    private String detectFileEncoding(String filename) throws IOException {
+    private String detectFileEncoding(String filename) throws IOException, URISyntaxException {
         String result;
         URL url = XmlXpathIndexerTest.class.getResource(filename);
-        SimpleXmlElementExtractor xee = new SimpleXmlElementExtractor();
+        File f = new File(url.toURI());
+        SimpleXmlElementExtractor xee = new SimpleXmlElementExtractor(f);
         result = xee.detectFileEncoding( url );
         return result;
     }
@@ -89,7 +90,7 @@ public class XmlXpathIndexerTest {
 
             // ----- index creation ------ //
             StandardXpathIndex index = XmlXpathIndexer.buildIndex( is );
-            is.close();
+            
             Assert.assertNotNull( "Index was not created!", index );
 
             // ----- extraction of XML snippets using index and extractor ------ //

--- a/src/test/java/psidev/psi/tools/xxindex/index/EncodingTest.java
+++ b/src/test/java/psidev/psi/tools/xxindex/index/EncodingTest.java
@@ -27,13 +27,13 @@ public class EncodingTest {
             InputStream is = url.openStream();
             StandardXpathIndex index = XmlXpathIndexer.buildIndex(is);
             IndexElement range = index.getElements("/first/second/third/fourth").get(1);
-
-            SimpleXmlElementExtractor xee = new SimpleXmlElementExtractor();
+            File file = new File(url.toURI());
+            SimpleXmlElementExtractor xee = new SimpleXmlElementExtractor(file);
             String encoding = xee.detectFileEncoding(url);
             if (encoding != null) {
                 xee.setEncoding(encoding);
             }
-            String xmlSnippet = xee.readString(range.getStart(), range.getStop(), new File(url.toURI()));
+            String xmlSnippet = xee.readString(range.getStart(), range.getStop());
             Assert.assertTrue( xmlSnippet.startsWith("<fourth>"));
             Assert.assertTrue( xmlSnippet.endsWith("</fourth>"));
         }


### PR DESCRIPTION
Performance is improved by avoiding continuous closing and re-opening of
the input XML file. Instead, the input file is opened (by creating the
FileInputStream or RandomAccessFile) once, and remains open throughout
the use of the class, until it is collected by the garbage collector.

This pull request addresses issue #1.