### PR TITLE
Removed logback classes from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,16 +107,6 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.12</version>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>1.1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
-        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Only slf4j-api should be declared for libraries, so the users of these
libraries can provide their selected slf4j front-end.