### PR TITLE
add possibility to close xml file manually

### DIFF
--- a/src/main/java/psidev/psi/tools/xxindex/StandardXpathAccess.java
+++ b/src/main/java/psidev/psi/tools/xxindex/StandardXpathAccess.java
@@ -130,6 +130,8 @@ public class StandardXpathAccess implements XpathAccess {
         return index;
     }
 
+    public XmlElementExtractor getExtractor() { return extractor; }
+
     public boolean isIgnoreNSPrefix() {
         return ignoreNSPrefix;
     }

--- a/src/main/java/psidev/psi/tools/xxindex/XmlElementExtractor.java
+++ b/src/main/java/psidev/psi/tools/xxindex/XmlElementExtractor.java
@@ -20,4 +20,5 @@ public interface XmlElementExtractor {
 
     String detectFileEncoding(URL fileLocation, int length) throws IOException;
 
+    default void releaseResources(){/*noop*/}
 }


### PR DESCRIPTION
It would be greate to have possibility to delete mzml file after parsing was completed. But it's not possible because file is stayed open untill GC woun't destroy elementExtractor object.